### PR TITLE
Identifiable Resources

### DIFF
--- a/Sources/HMV/CoreObjects/Resource.swift
+++ b/Sources/HMV/CoreObjects/Resource.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct Resource<AttributesType: Codable, RelationshipsType: Codable>: Codable {
+public struct Resource<AttributesType: Codable, RelationshipsType: Codable>: Codable, Identifiable {
     public let id: String
     public let type: MediaType
     public let href: String


### PR DESCRIPTION
As a <Resource> already has an id: property, this makes it conform to the Identifiable protocol so that in e.g. SwiftUI it can be iterated over in a ForEach (vs. doing i in resource.count() or similar.)